### PR TITLE
Send announcements example

### DIFF
--- a/a4b-announcements-api/README.md
+++ b/a4b-announcements-api/README.md
@@ -1,0 +1,11 @@
+# :rocket: Using the Amazon Alexa for Business (A4B) API to send announcements :rocket:
+
+## Introduction
+
+This sample code shows how to [Send Announcements](https://docs.aws.amazon.com/a4b/latest/ag/announcements.html) to rooms in A4B using the [JavaScript SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/AlexaForBusiness.html#sendAnnouncement-property).
+
+It uses text messages, but can be extended to use SSML and / or Audio. For the rooms, I used the Key RoomName, but it can be switched to using the Room ARN, Profile ARN, or the Profile Name
+
+## Prerequisites
+
+This code should be run with using AWS credentials with access granted to Alexa for Business

--- a/a4b-announcements-api/README.md
+++ b/a4b-announcements-api/README.md
@@ -1,11 +1,11 @@
-# :rocket: Using the Amazon Alexa for Business (A4B) API to send announcements :rocket:
+## :rocket: Using the Amazon Alexa for Business (A4B) API to send announcements
 
-## Introduction
+### Introduction
 
-This sample code shows how to [Send Announcements](https://docs.aws.amazon.com/a4b/latest/ag/announcements.html) to rooms in A4B using the [JavaScript SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/AlexaForBusiness.html#sendAnnouncement-property).
+This sample code shows how to [Send Announcements](https://docs.aws.amazon.com/a4b/latest/ag/announcements.html) to rooms in A4B using the [JavaScript SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/AlexaForBusiness.html#sendAnnouncement-property). It uses passed in string messages. For the rooms, the script uses the Key RoomName, or Room ARN.
 
-It uses text messages, but can be extended to use SSML and / or Audio. For the rooms, I used the Key RoomName, but it can be switched to using the Room ARN, Profile ARN, or the Profile Name
+The message is case-insensitive and the Room name / Room ARN is case-sensitive.
 
-## Prerequisites
+### Prerequisites
 
-This code should be run with using AWS credentials with access granted to Alexa for Business
+This code should be run with using AWS credentials with AlexaForBusinessFullAccess.

--- a/a4b-announcements-api/README.md
+++ b/a4b-announcements-api/README.md
@@ -8,4 +8,4 @@ The message is case-insensitive and the Room name / Room ARN is case-sensitive.
 
 ### Prerequisites
 
-This code should be run with using AWS credentials with AlexaForBusinessFullAccess.
+This code should be run using AWS credentials with AlexaForBusinessFullAccess permissions.

--- a/a4b-announcements-api/index.js
+++ b/a4b-announcements-api/index.js
@@ -1,6 +1,9 @@
 var AWS = require("aws-sdk");
 var A4B = new AWS.AlexaForBusiness({ region: "us-east-1" });
 
+/**
+ * @description Return a unique ID
+ */
 function getToken() {
     return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
         var r = (Math.random() * 16) | 0,
@@ -9,11 +12,31 @@ function getToken() {
     });
 }
 
+/**
+ * @description Send in string messages using the A4B sendAnnouncement API operation
+ * @param  {String} roomName=undefined This is a case-sensitive parameter to specify the room name
+ * @param  {String} roomARN=undefined This is a case-sensitive parameter to specify the room ARN
+ * @param  {String} message="Hello folks this is a default announcement" This is a case-insensitive parameter to specify the message to send
+ * @param  {integer} ttl=300
+ * @example <caption> Example of usage with Room Name</caption>
+ * sendAnnouncement("Room Name", undefined,"Please leave the room until it reaches it's max capacity!");
+ * @example <caption> Example of usage with Room ARN</caption>
+ * sendAnnouncement( undefined,"Room ARN","This room as reached MAX capacity and no one else can be admitted into this room");
+ */
 async function sendAnnouncement(
-    roomName,
+    roomName = undefined,
+    roomARN = undefined,
     message = "Hello folks, this is a default announcement",
     ttl = 300
 ) {
+    var roomKey = "RoomName";
+    var room = roomName;
+
+    if (!roomName && roomARN) {
+        roomKey = "RoomArn";
+        room = roomARN;
+    }
+
     var params = {
         ClientRequestToken: getToken(),
         Content: {
@@ -26,10 +49,9 @@ async function sendAnnouncement(
         },
         RoomFilters: [
             {
-                Key: "RoomName" /* required */,
-                Values: [/* required */ roomName],
+                Key: roomKey,
+                Values: [room],
             },
-            /* more items */
         ],
         TimeToLiveInSeconds: ttl,
     };
@@ -39,8 +61,3 @@ async function sendAnnouncement(
         else console.log(data); // successful response
     });
 }
-
-sendAnnouncement(
-    "war room",
-    "This room as reached MAX capacity and no one else can be admitted into this room"
-);

--- a/a4b-announcements-api/index.js
+++ b/a4b-announcements-api/index.js
@@ -1,0 +1,46 @@
+var AWS = require("aws-sdk");
+var A4B = new AWS.AlexaForBusiness({ region: "us-east-1" });
+
+function getToken() {
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+        var r = (Math.random() * 16) | 0,
+            v = c == "x" ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+    });
+}
+
+async function sendAnnouncement(
+    roomName,
+    message = "Hello folks, this is a default announcement",
+    ttl = 300
+) {
+    var params = {
+        ClientRequestToken: getToken(),
+        Content: {
+            TextList: [
+                {
+                    Locale: "en-US",
+                    Value: message,
+                },
+            ],
+        },
+        RoomFilters: [
+            {
+                Key: "RoomName" /* required */,
+                Values: [/* required */ roomName],
+            },
+            /* more items */
+        ],
+        TimeToLiveInSeconds: ttl,
+    };
+    await A4B.sendAnnouncement(params, function (err, data) {
+        if (err) console.log(err, err.stack);
+        // an error occurred
+        else console.log(data); // successful response
+    });
+}
+
+sendAnnouncement(
+    "war room",
+    "This room as reached MAX capacity and no one else can be admitted into this room"
+);


### PR DESCRIPTION
I've added this code sample to show how to use the sendAnnouncement operation using the AWS JavaScript SDK. It uses text messages, but can be extended to use SSML and / or Audio. For the rooms, I used the Key RoomName, but it can be switched to using the Room ARN, Profile ARN, or the Profile Name

*Issue #, if available: N/A

*Description of changes: This is an addition of a sample code to send announcements in A4B


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
